### PR TITLE
fix: finish cluster setup

### DIFF
--- a/tofu/envs/prod/argocd.tf
+++ b/tofu/envs/prod/argocd.tf
@@ -3,22 +3,22 @@ data "google_secret_manager_secret_version" "argocd_app_pem_key" {
 }
 
 resource "kubernetes_namespace_v1" "argocd" {
-  depends_on = [ module.talos ]
+  depends_on = [module.talos, hcloud_load_balancer_service.this]
 
   metadata {
     name = "argocd"
 
     labels = {
-      name = "argocd"
+      name                                 = "argocd"
       "pod-security.kubernetes.io/enforce" = "privileged"
     }
   }
 }
 
 resource "helm_release" "argocd" {
-  depends_on = [module.talos, kubernetes_namespace_v1.argocd]
+  depends_on = [module.talos, kubernetes_namespace_v1.argocd, hcloud_load_balancer_service.this]
   name       = "argocd"
-  namespace = kubernetes_namespace_v1.argocd.metadata[0].name
+  namespace  = kubernetes_namespace_v1.argocd.metadata[0].name
 
   repository = "https://argoproj.github.io/argo-helm"
   chart      = "argo-cd"
@@ -28,9 +28,9 @@ resource "helm_release" "argocd" {
 }
 
 resource "kubernetes_secret_v1" "argocd_repo_access" {
-  depends_on = [module.talos, helm_release.argocd, kubernetes_namespace_v1.argocd ]
+  depends_on = [module.talos, helm_release.argocd, kubernetes_namespace_v1.argocd]
   metadata {
-    name = "argo-private-repo-secret"
+    name      = "argo-private-repo-secret"
     namespace = kubernetes_namespace_v1.argocd.metadata[0].name
 
     labels = {
@@ -48,14 +48,14 @@ resource "kubernetes_secret_v1" "argocd_repo_access" {
 }
 
 resource "argocd_application" "cluster_config" {
-  depends_on = [ kubernetes_secret_v1.argocd_repo_access, helm_release.argocd, kubernetes_namespace_v1.argocd ]
+  depends_on = [kubernetes_secret_v1.argocd_repo_access, helm_release.argocd, kubernetes_namespace_v1.argocd]
 
   metadata {
     name      = "cluster-config"
     namespace = kubernetes_namespace_v1.argocd.metadata[0].name
   }
 
-  wait = true
+  wait = false
 
   spec {
     destination {
@@ -63,8 +63,8 @@ resource "argocd_application" "cluster_config" {
     }
 
     source {
-      repo_url = "https://github.com/malachowski-labs/manifests"
-      path = "clusters/prod.malachowski.me"
+      repo_url        = "https://github.com/malachowski-labs/manifests"
+      path            = "clusters/prod.malachowski.me"
       target_revision = "HEAD"
 
       directory {
@@ -74,7 +74,7 @@ resource "argocd_application" "cluster_config" {
 
     sync_policy {
       automated {
-        prune = true
+        prune     = true
         self_heal = true
       }
 
@@ -87,10 +87,10 @@ resource "argocd_application" "cluster_config" {
 }
 
 resource "argocd_application" "traefik" {
-  depends_on = [ helm_release.argocd, kubernetes_namespace_v1.argocd, hcloud_load_balancer.this ]
+  depends_on = [helm_release.argocd, kubernetes_namespace_v1.argocd, hcloud_load_balancer.this]
 
   metadata {
-    name = "argo-traefik-chart"
+    name      = "argo-traefik-chart"
     namespace = kubernetes_namespace_v1.argocd.metadata[0].name
   }
 
@@ -102,8 +102,8 @@ resource "argocd_application" "traefik" {
     }
 
     source {
-      repo_url = "https://github.com/traefik/traefik-helm-chart.git"
-      path = "traefik"
+      repo_url        = "https://github.com/traefik/traefik-helm-chart.git"
+      path            = "traefik"
       target_revision = "v38.0.2"
 
       helm {
@@ -123,7 +123,7 @@ resource "argocd_application" "traefik" {
 
     sync_policy {
       automated {
-        prune = true
+        prune     = true
         self_heal = true
       }
 

--- a/tofu/envs/prod/external-secret-operator.tf
+++ b/tofu/envs/prod/external-secret-operator.tf
@@ -69,7 +69,7 @@ resource "google_service_account_iam_member" "workload_identity_binding" {
 
 # Namespace for OIDC discovery service
 resource "kubernetes_namespace_v1" "oidc_discovery" {
-  depends_on = [module.talos]
+  depends_on = [module.talos, hcloud_load_balancer_service.this]
 
   metadata {
     name = "oidc-discovery"
@@ -320,7 +320,7 @@ resource "kubernetes_ingress_v1" "oidc_discovery" {
 # =====================================
 
 resource "kubernetes_namespace_v1" "external_secrets" {
-  depends_on = [module.talos]
+  depends_on = [module.talos, hcloud_load_balancer_service.this]
 
   metadata {
     name = local.eso_namespace
@@ -352,7 +352,8 @@ resource "helm_release" "external_secrets" {
   depends_on = [
     kubernetes_namespace_v1.external_secrets,
     kubernetes_service_account_v1.external_secrets,
-    module.talos
+    module.talos,
+    hcloud_load_balancer_service.this
   ]
 
   name       = "external-secrets"

--- a/tofu/envs/prod/servers.tf
+++ b/tofu/envs/prod/servers.tf
@@ -5,7 +5,7 @@ locals {
   ]
 
   control_plane_nodes = [
-    for i in range(0, 3) : {
+    for i in range(0, 1) : {
       id     = i + 1
       name   = "prod-malachowski-me-cp-${i}"
       labels = { role = "control-plane" }
@@ -71,6 +71,13 @@ resource "hcloud_load_balancer_target" "this" {
   load_balancer_id = hcloud_load_balancer.this.id
   label_selector   = "role=control-plane"
   use_private_ip   = true
+}
+
+resource "hcloud_load_balancer_service" "this" {
+  load_balancer_id = hcloud_load_balancer.this.id
+  protocol         = "tcp"
+  listen_port      = 6443
+  destination_port = 6443
 }
 
 


### PR DESCRIPTION
# Description

This pull request updates the infrastructure configuration for the production environment, primarily to ensure that key Kubernetes resources and Helm releases depend on the new `hcloud_load_balancer_service.this` resource. Additionally, it changes the control plane node count and disables waiting on ArgoCD application creation. The most important changes are grouped below:

**Load Balancer Integration and Dependency Updates:**

* Added a new resource `hcloud_load_balancer_service.this` in `servers.tf` to manage load balancer service for TCP traffic on port 6443.
* Updated `depends_on` for multiple Kubernetes namespaces and Helm releases (`argocd`, `oidc_discovery`, `external_secrets`) to include `hcloud_load_balancer_service.this`, ensuring these resources are only created after the load balancer service is ready. [[1]](diffhunk://#diff-e2a7a395c5d6812fe612198b5bd1da43bbb9eb2337d5c7a8ccae8746a28abf8eL6-R6) [[2]](diffhunk://#diff-e2a7a395c5d6812fe612198b5bd1da43bbb9eb2337d5c7a8ccae8746a28abf8eL19-R19) [[3]](diffhunk://#diff-d0593ca98225d6f38c89c737e299ef1e24fe335bc858d3d6e7fc66eb20c63f9bL72-R72) [[4]](diffhunk://#diff-d0593ca98225d6f38c89c737e299ef1e24fe335bc858d3d6e7fc66eb20c63f9bL323-R323) [[5]](diffhunk://#diff-d0593ca98225d6f38c89c737e299ef1e24fe335bc858d3d6e7fc66eb20c63f9bL355-R356)

**Cluster Topology Change:**

* Reduced the number of control plane nodes from 3 to 1 in the `control_plane_nodes` local definition, which may impact high availability.

**ArgoCD Application Behavior:**

* Set `wait = false` in the `argocd_application.cluster_config` resource, so Terraform does not wait for the application to sync before continuing.