### PR TITLE
fix(iac): configure location of argo apps

### DIFF
--- a/tofu/envs/prod/argocd.tf
+++ b/tofu/envs/prod/argocd.tf
@@ -156,7 +156,7 @@ resource "kubectl_manifest" "cluster_config" {
 
       source = {
         repoURL        = "https://github.com/malachowski-labs/manifests"
-        path           = "clusters/prod.malachowski.me"
+        path           = "clusters/prod.malachowski.me/apps"
         targetRevision = "HEAD"
 
         directory = {


### PR DESCRIPTION
Switch from whole configuration in single directory, to have simply use ArgoCD apps, so now the details of the configuration will be handled by the  ArgoCD configured recursively in the manifest repository.